### PR TITLE
Update DB2Grammar.php

### DIFF
--- a/src/Query/Grammars/DB2Grammar.php
+++ b/src/Query/Grammars/DB2Grammar.php
@@ -79,7 +79,7 @@ class DB2Grammar extends Grammar
 
         $columns = (!empty($components['columns']) ? $components['columns'] . ', ': 'select');
 
-        $components['columns'] = $this->compileOver($orderings, $columns);
+        $components['columns'] = $this->compileOver($orderings);
 
         unset($components['orders']);
 
@@ -104,9 +104,9 @@ class DB2Grammar extends Grammar
      * @param  string  $orderings
      * @return string
      */
-    protected function compileOver($orderings, $columns)
+    protected function compileOver($orderings)
     {
-        return "{$columns} row_number() over ({$orderings}) as row_num";
+        return "select row_number() over ({$orderings}) as row_num";
     }
 
     protected function compileRowConstraint($query)


### PR DESCRIPTION
Changed compile over to not include column names. This was throwing an error while chunking results from the db2. The comma in "select $column_names," was throwing a SQL syntax error. As far as I can tell, the only time this is used is when chunking results, so the column names shouldn't be included.
